### PR TITLE
New feature: escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ Igroups can also be nested:
 (+a|(+b|c)) => ['a', 'ab', 'abc', 'ac', 'b', 'bc', 'c']
 ```
 
+### Escaping
+
+You can escape special characters by using a backslash (`\`):
+
+```
+\(a\|b\) => ['(a|b)']
+```
+
 ### Complex patterns
 
 Finally, you can mix all of them into complex patterns:

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -6,5 +6,15 @@ export const RightParenthesis = createToken({ name: 'RightParenthesis', pattern:
 export const QuestionMark = createToken({ name: 'QuestionMark', pattern: '?' });
 export const Pipe = createToken({ name: 'Pipe', pattern: '|' });
 export const PlusSign = createToken({ name: 'PlusSign', pattern: '+' });
+export const Backslash = createToken({ name: 'Backslash', pattern: '\\' });
 
-export default [Text, LeftParenthesis, RightParenthesis, QuestionMark, Pipe, PlusSign];
+export const escapableTokens = [
+  Backslash,
+  LeftParenthesis,
+  Pipe,
+  PlusSign,
+  QuestionMark,
+  RightParenthesis,
+];
+
+export default [...escapableTokens, Text];

--- a/tests/escaping.spec.ts
+++ b/tests/escaping.spec.ts
@@ -1,0 +1,41 @@
+import { escapableTokens } from '../src/tokens';
+
+import expand from '../src';
+
+describe('escaping', () => {
+  it('should escape escaped tokens', () => {
+    const result = expand(escapableTokens.map((token) => `\\${token.PATTERN}`).join('')).sort();
+
+    expect(result).toEqual([escapableTokens.map((token) => token.PATTERN).join('')].sort());
+  });
+
+  it('should escape escape parenthesis', () => {
+    const result = expand('(\\(\\))').sort();
+
+    expect(result).toEqual(['()'].sort());
+  });
+
+  it('should escape pipe', () => {
+    const result = expand('(\\||a)').sort();
+
+    expect(result).toEqual(['|', 'a'].sort());
+  });
+
+  it('should escape plus sign', () => {
+    const result = expand('(+\\+|a)').sort();
+
+    expect(result).toEqual(['+', 'a', '+a'].sort());
+  });
+
+  it('should escape question mark', () => {
+    const result = expand('\\??').sort();
+
+    expect(result).toEqual(['?', ''].sort());
+  });
+
+  it('should escape backslash', () => {
+    const result = expand('\\\\').sort();
+
+    expect(result).toEqual(['\\'].sort());
+  });
+});

--- a/tests/igroups.spec.ts
+++ b/tests/igroups.spec.ts
@@ -1,25 +1,25 @@
 import expand from '../src';
 
 describe('inclusive groups', () => {
-  it('should expand inclusive groups', () => {
+  it('should expand igroups', () => {
     const result = expand('(+a|b)').sort();
 
     expect(result).toEqual(['a', 'b', 'ab'].sort());
   });
 
-  it('should expand optional inclusive groups', () => {
+  it('should expand optional igroups', () => {
     const result = expand('(+a|b)?').sort();
 
     expect(result).toEqual(['a', 'b', 'ab', ''].sort());
   });
 
-  it('should not expand single-option inclusive groups', () => {
+  it('should not expand single-option igroups', () => {
     const result = expand('(+a)').sort();
 
     expect(result).toEqual(['a'].sort());
   });
 
-  it('should expand nested inclusive groups', () => {
+  it('should expand nested igroups', () => {
     const result = expand('(+a|(+b|c))').sort();
 
     expect(result).toEqual(['a', 'ab', 'abc', 'ac', 'b', 'bc', 'c'].sort());


### PR DESCRIPTION
This PR adds a new escaping feature. It allows you to escape special characters by using a backslash (`\`):

```
\(a\|b\) => ['(a|b)']
```