### PR TITLE
Broaden TEXT token pattern to accept all non-special characters

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -28,7 +28,7 @@ export const tokenDefinitions: TokenDefinition[] = [
   { type: TokenType.PIPE, pattern: /^\|/, escapable: true },
   { type: TokenType.PLUS_SIGN, pattern: /^\+/, escapable: true },
   { type: TokenType.BACKSLASH, pattern: /^\\/, escapable: true },
-  { type: TokenType.TEXT, pattern: /^(\w|\s)+/, escapable: false },
+  { type: TokenType.TEXT, pattern: /^[^()?|+\\]+/, escapable: false },
   { type: TokenType.EOF, pattern: /^$/, escapable: false },
 ];
 

--- a/tests/expand/basic.spec.ts
+++ b/tests/expand/basic.spec.ts
@@ -12,4 +12,10 @@ describe('basic', () => {
 
     expect(result).toEqual(['a', 'ab'].sort());
   });
+
+  it('should expand text with non-ASCII and special characters', () => {
+    const result = expand('café-latte');
+
+    expect(result).toEqual(['café-latte']);
+  });
 });

--- a/tests/lexer.spec.ts
+++ b/tests/lexer.spec.ts
@@ -59,6 +59,15 @@ describe('lexer', () => {
       expect(tokens[tokens.length - 1].type).toBe(TokenType.EOF);
     });
 
+    it('should tokenize text with non-ASCII and special characters', () => {
+      const tokens = lexer.tokenize('café-latte');
+
+      expect(tokens).toEqual([
+        { type: TokenType.TEXT, value: 'café-latte', position: 0 },
+        { type: TokenType.EOF, value: '', position: 10 },
+      ]);
+    });
+
     it('should track token positions', () => {
       const tokens = lexer.tokenize('a(b|c)');
 

--- a/tests/lexer.spec.ts
+++ b/tests/lexer.spec.ts
@@ -75,11 +75,4 @@ describe('lexer', () => {
     });
   });
 
-  describe('errors', () => {
-    it('should throw on unsupported characters', () => {
-      expect(() => lexer.tokenize('ax-by')).toThrow(
-        "Unexpected character '-' at position 2",
-      );
-    });
-  });
 });


### PR DESCRIPTION
## Summary

- Broadens the TEXT token regex from `/^(\w|\s)+/` to `/^[^()?|+\\]+/` so any character that isn't a special token is valid text
- Adds tests for non-ASCII and special characters (e.g. `café-latte`)
- Removes the "should throw on unsupported characters" test since all non-special characters are now valid

## Test plan

- [x] New lexer test tokenizes `café-latte` as a single TEXT token
- [x] New expansion test expands `café-latte` to `['café-latte']`
- [x] All existing tests pass
- [x] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)