### PR TITLE
Rename "inclusive groups" to "additive groups"

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ Groups can be nested arbitrarily:
 (a(b|c)) => ['ab', 'ac']
 ```
 
-### Inclusive groups
+### Additive groups
 
-Prefix the group with `+` to also output every combination of its options:
+Prefix the group with `+` to also output all options individually plus their
+full concatenation in order:
 
 ```
 (+a|b) => ['a', 'b', 'ab']
@@ -100,13 +101,13 @@ concatenated in order — not every pairwise combination:
 (+a|b|c) => ['a', 'b', 'c', 'abc']
 ```
 
-Optional inclusive groups include the empty string:
+Optional additive groups include the empty string:
 
 ```
 (+a|b)? => ['', 'a', 'b', 'ab']
 ```
 
-Inclusive groups can be nested:
+Additive groups can be nested:
 
 ```
 (+a|(+b|c)) => ['a', 'ab', 'abc', 'ac', 'b', 'bc', 'c']

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -132,8 +132,8 @@ export default class Parser {
 
     this.consume(TokenType.LEFT_PAREN);
 
-    const isIgroup = this.match(TokenType.PLUS_SIGN);
-    if (isIgroup) {
+    const isAdditiveGroup = this.match(TokenType.PLUS_SIGN);
+    if (isAdditiveGroup) {
       this.advance();
     }
 
@@ -146,7 +146,7 @@ export default class Parser {
 
     this.consume(TokenType.RIGHT_PAREN);
 
-    if (isIgroup && alternatives.length > 1) {
+    if (isAdditiveGroup && alternatives.length > 1) {
       alternatives.push(new And(...alternatives));
     }
 

--- a/tests/expand/agroups.spec.ts
+++ b/tests/expand/agroups.spec.ts
@@ -1,25 +1,25 @@
 import expand from '../../src';
 
-describe('inclusive groups', () => {
-  it('should expand igroups', () => {
+describe('additive groups', () => {
+  it('should expand additive groups', () => {
     const result = expand('(+a|b)').sort();
 
     expect(result).toEqual(['a', 'b', 'ab'].sort());
   });
 
-  it('should expand optional igroups', () => {
+  it('should expand optional additive groups', () => {
     const result = expand('(+a|b)?').sort();
 
     expect(result).toEqual(['a', 'b', 'ab', ''].sort());
   });
 
-  it('should not expand single-option igroups', () => {
+  it('should not expand single-option additive groups', () => {
     const result = expand('(+a)').sort();
 
     expect(result).toEqual(['a'].sort());
   });
 
-  it('should expand nested igroups', () => {
+  it('should expand nested additive groups', () => {
     const result = expand('(+a|(+b|c))').sort();
 
     expect(result).toEqual(['a', 'ab', 'abc', 'ac', 'b', 'bc', 'c'].sort());


### PR DESCRIPTION
## Summary

- Renames `isIgroup` → `isAdditiveGroup` in `src/parser.ts`
- Renames `tests/expand/igroups.spec.ts` → `agroups.spec.ts` and updates all `describe`/`it` labels
- Updates README section heading and prose to use "additive groups"

Closes #14

## Test plan

- [x] All existing tests pass (`yarn test`)
- [x] No logic changes — purely a rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)