### PR TITLE
Add ESM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 Expand string patterns into all possible combinations.
 
 ```js
+// CommonJS
 const expand = require('string-expansion');
+
+// ESM
+import expand from 'string-expansion';
 
 expand('(Mary|John) Smith(son)?');
 // => ['Mary Smith', 'Mary Smithson', 'John Smith', 'John Smithson']
 ```
-
-> **Note:** Only CommonJS (`require`) is supported at this time. ESM support is
-> tracked in [#12](https://github.com/lfbittencourt/string-expansion/issues/12).
 
 ## Use cases
 

--- a/package.json
+++ b/package.json
@@ -2,14 +2,22 @@
   "name": "string-expansion",
   "version": "0.0.0",
   "description": "Expand string patterns into all possible combinations",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "types": "dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/cjs/index.d.ts"
+    }
+  },
   "author": "LF Bittencourt <lf@lfbittencourt.com>",
   "license": "MIT",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "test": "jest"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 import expandTree from './expand-tree';
 import patternToTree from './pattern-to-tree';
 
-export = (pattern: string) => expandTree(patternToTree(pattern));
+export default (pattern: string) => expandTree(patternToTree(pattern));

--- a/src/pattern-to-tree.ts
+++ b/src/pattern-to-tree.ts
@@ -4,7 +4,7 @@ import Parser from './parser';
 const lexer = new Lexer();
 const parser = new Parser();
 
-export = (pattern: string) => {
+export default (pattern: string) => {
   const tokens = lexer.tokenize(pattern);
   const tree = parser.parse(tokens);
 

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs/",
+    "declaration": true
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./dist/esm/"
+  }
+}


### PR DESCRIPTION
## Summary

- Converts `export =` to `export default` in `src/index.ts` and `src/pattern-to-tree.ts` — `export =` is CJS-only and errors when targeting ES modules
- Adds `tsconfig.cjs.json` compiling to `dist/cjs/` with declaration files
- Adds `tsconfig.esm.json` compiling to `dist/esm/` with `module: ESNext`
- Updates `package.json` with an `exports` map, `main` pointing to `dist/cjs/index.js`, and a `types` field
- Removes the CJS-only note from README and adds both `require` and `import` examples

Closes #12

## Test plan

- [x] `yarn build` compiles both CJS (`dist/cjs/`) and ESM (`dist/esm/`) without errors
- [x] `yarn test` — all 34 tests pass
- [x] Type declarations (`*.d.ts`) are generated in `dist/cjs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)