### PR TITLE
Switch publish workflow to npm Trusted Publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
 
       - name: Checkout code
@@ -40,6 +43,4 @@ jobs:
         run: yarn version --new-version ${{ github.event.release.tag_name }} --no-git-tag-version
 
       - name: Publish to NPM
-        run: yarn publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Replace token-based auth (`NPM_TOKEN`) with OIDC-based Trusted Publishers
- Add `id-token: write` permission for OIDC authentication
- Use `npm publish --provenance` instead of `yarn publish` (yarn doesn't support `--provenance`)

## Context
The v1.5.0 publish failed because `NPM_TOKEN` was never set. Trusted Publishers removes the need for a static token entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)